### PR TITLE
Turn counter

### DIFF
--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -99,6 +99,7 @@ const AP_Scheduler::Task Sub::scheduler_tasks[] = {
     SCHED_TASK(run_nav_updates,       50,    100),
     SCHED_TASK(update_thr_average,   100,     90),
     SCHED_TASK(three_hz_loop,          3,     75),
+	SCHED_TASK(update_turn_counter,   10,     50),
     SCHED_TASK(compass_accumulate,   100,    100),
     SCHED_TASK(barometer_accumulate,  50,     90),
 #if PRECISION_LANDING == ENABLED

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -424,6 +424,10 @@ private:
     float baro_climbrate;        // barometer climbrate in cm/s
     LowPassFilterVector3f land_accel_ef_filter; // accelerations for land and crash detector tests
 
+    // Turn counter
+    int32_t turn_count;
+    float last_turn_count_yaw;
+
     // filtered pilot's throttle input used to cancel landing if throttle held high
     LowPassFilterFloat rc_throttle_control_in_filter;
 
@@ -582,6 +586,7 @@ private:
     void three_hz_loop();
     void one_hz_loop();
     void update_GPS(void);
+    void update_turn_counter();
     void init_simple_bearing();
     void update_simple_mode(void);
     void update_super_simple_bearing(bool force_update);

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -425,8 +425,8 @@ private:
     LowPassFilterVector3f land_accel_ef_filter; // accelerations for land and crash detector tests
 
     // Turn counter
-    int32_t turn_count;
-    float last_turn_count_yaw;
+    int32_t quarter_turn_count;
+    uint8_t last_turn_state;
 
     // filtered pilot's throttle input used to cancel landing if throttle held high
     LowPassFilterFloat rc_throttle_control_in_filter;

--- a/ArduSub/turn_counter.cpp
+++ b/ArduSub/turn_counter.cpp
@@ -6,15 +6,56 @@
 // Count total vehicle turns to avoid tangling tether
 void Sub::update_turn_counter()
 {
+	// Determine state
+	// 0: 0-90 deg, 1: 90-180 deg, 2: -180--90 deg, 3: -90--0 deg
+	uint8_t turn_state;
+	if ( ahrs.yaw >= 0.0f && ahrs.yaw < 90.0f ) {
+		turn_state = 0;
+	} else if ( ahrs.yaw > 90.0f ) {
+		turn_state = 1;
+	} else if ( ahrs.yaw < -90.0f ) {
+		turn_state = 2;
+	} else if ( ahrs.yaw < 0.0f && ahrs.yaw > -90.0f) {
+		turn_state = 3;
+	}
+
 	// If yaw went from negative to positive (right turn)
-	if ( ahrs.yaw > 0 && last_turn_count_yaw < 0 ) {
-		turn_count++;
-		gcs_send_text_fmt(MAV_SEVERITY_INFO,"Turn count: %i turns to the right",turn_count);
+	switch (last_turn_state) {
+	case 0:
+		if ( turn_state == 1 ) {
+			quarter_turn_count++;
+		}
+		if ( turn_state == 3 ) {
+			quarter_turn_count--;
+		}
+		break;
+	case 1:
+		if ( turn_state == 2 ) {
+			quarter_turn_count++;
+		}
+		if ( turn_state == 0 ) {
+			quarter_turn_count--;
+		}
+		break;
+	case 2:
+		if ( turn_state == 3 ) {
+			quarter_turn_count++;
+		}
+		if ( turn_state == 1 ) {
+			quarter_turn_count--;
+		}
+		break;
+	case 3:
+		if ( turn_state == 0 ) {
+			quarter_turn_count++;
+		}
+		if ( turn_state == 2 ) {
+			quarter_turn_count--;
+		}
+		break;
 	}
-	// If yaw went from positive to negative (left turn)
-	if ( ahrs.yaw < 0 && last_turn_count_yaw > 0 ) {
-		turn_count--;
-		gcs_send_text_fmt(MAV_SEVERITY_INFO,"Turn count: %i turns to the right",turn_count);
+	if ( turn_state != last_turn_state ) {
+		gcs_send_text_fmt(MAV_SEVERITY_INFO,"Turn count: %3.2f turns to the right",quarter_turn_count/4.0f);
 	}
-	last_turn_count_yaw = ahrs.yaw;
+	last_turn_state = turn_state;
 }

--- a/ArduSub/turn_counter.cpp
+++ b/ArduSub/turn_counter.cpp
@@ -1,0 +1,20 @@
+/// -*- tab-width: 4; Mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*-
+// Code by Rustom Jehangir: rusty@bluerobotics.com
+
+#include "Sub.h"
+
+// Count total vehicle turns to avoid tangling tether
+void Sub::update_turn_counter()
+{
+	// If yaw went from negative to positive (right turn)
+	if ( ahrs.yaw > 0 && last_turn_count_yaw < 0 ) {
+		turn_count++;
+		gcs_send_text_fmt(MAV_SEVERITY_INFO,"Turn count: %i turns to the right",turn_count);
+	}
+	// If yaw went from positive to negative (left turn)
+	if ( ahrs.yaw < 0 && last_turn_count_yaw > 0 ) {
+		turn_count--;
+		gcs_send_text_fmt(MAV_SEVERITY_INFO,"Turn count: %i turns to the right",turn_count);
+	}
+	last_turn_count_yaw = ahrs.yaw;
+}

--- a/ArduSub/turn_counter.cpp
+++ b/ArduSub/turn_counter.cpp
@@ -9,13 +9,13 @@ void Sub::update_turn_counter()
 	// Determine state
 	// 0: 0-90 deg, 1: 90-180 deg, 2: -180--90 deg, 3: -90--0 deg
 	uint8_t turn_state;
-	if ( ahrs.yaw >= 0.0f && ahrs.yaw < 90.0f ) {
+	if ( ahrs.yaw >= 0.0f && ahrs.yaw < radians(90) ) {
 		turn_state = 0;
-	} else if ( ahrs.yaw > 90.0f ) {
+	} else if ( ahrs.yaw > radians(90) ) {
 		turn_state = 1;
-	} else if ( ahrs.yaw < -90.0f ) {
+	} else if ( ahrs.yaw < -radians(90) ) {
 		turn_state = 2;
-	} else if ( ahrs.yaw < 0.0f && ahrs.yaw > -90.0f) {
+	} else {
 		turn_state = 3;
 	}
 
@@ -54,8 +54,10 @@ void Sub::update_turn_counter()
 		}
 		break;
 	}
-	if ( turn_state != last_turn_state ) {
-		gcs_send_text_fmt(MAV_SEVERITY_INFO,"Turn count: %3.2f turns to the right",quarter_turn_count/4.0f);
+	static int32_t last_turn_count_printed;
+	if ( quarter_turn_count/4 != last_turn_count_printed ) {
+		gcs_send_text_fmt(MAV_SEVERITY_INFO,"Tether is turned %i turns %s",int32_t(quarter_turn_count/4),(quarter_turn_count>0)?"to the right":"to the left");
+		last_turn_count_printed = quarter_turn_count/4;
 	}
 	last_turn_state = turn_state;
 }


### PR DESCRIPTION
Adds a turn counter to help avoid tangling the tether during dives. Helps to spool the tether after the dive as well.

Turn counts are fairly primitive, relying on yaw direction changes only, even though a turn can also be generated by a roll or pitch rotation.

Prints to the info view for now until we can send through a MAVlink message.
