### PR TITLE
Sub GCS: Zero depth with MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS

### DIFF
--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -1382,17 +1382,38 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
         case MAV_CMD_PREFLIGHT_SET_SENSOR_OFFSETS:
         	{
                 uint8_t compassNumber = -1;
-                if (is_equal(packet.param1, 2.0f)) {
+                if (is_equal(packet.param1, 2.0f)) { // compass1
                     compassNumber = 0;
-                } else if (is_equal(packet.param1, 5.0f)) {
+                } else if (is_equal(packet.param1, 5.0f)) { // compass 2
                     compassNumber = 1;
-                } else if (is_equal(packet.param1, 6.0f)) {
+                } else if (is_equal(packet.param1, 6.0f)) { // compass 3
                     compassNumber = 2;
                 }
+
                 if (compassNumber != (uint8_t) -1) {
                     sub.compass.set_and_save_offsets(compassNumber, packet.param2, packet.param3, packet.param4);
                     result = MAV_RESULT_ACCEPTED;
+                    break;
+
                 }
+
+                if (is_equal(packet.param1, 3.0f)) { // depth sensor, set zero depth
+                	if(is_zero(packet.param2) &&
+                		is_zero(packet.param3) &&
+						is_zero(packet.param4) &&
+						is_zero(packet.param5) &&
+						is_zero(packet.param6) &&
+						is_zero(packet.param7))
+                	{
+                		if(!sub.ap.depth_sensor_present || sub.motors.armed() || sub.barometer.get_pressure() > 110000) {
+                			result = MAV_RESULT_FAILED;
+                			break;
+                		}
+                		sub.barometer.update_calibration();
+                		result = MAV_RESULT_ACCEPTED;
+                	}
+                }
+
                 break;
             }
 

--- a/ArduSub/GCS_Mavlink.cpp
+++ b/ArduSub/GCS_Mavlink.cpp
@@ -1394,7 +1394,6 @@ void GCS_MAVLINK_Sub::handleMessage(mavlink_message_t* msg)
                     sub.compass.set_and_save_offsets(compassNumber, packet.param2, packet.param3, packet.param4);
                     result = MAV_RESULT_ACCEPTED;
                     break;
-
                 }
 
                 if (is_equal(packet.param1, 3.0f)) { // depth sensor, set zero depth

--- a/libraries/AP_Baro/AP_Baro.cpp
+++ b/libraries/AP_Baro/AP_Baro.cpp
@@ -216,6 +216,10 @@ void AP_Baro::update_calibration()
             _EAS2TAS = 0;
         }
     }
+
+    // update and save base pressure (persistent between boots) with primary baro ground calibration (not persistent)
+    _base_pressure.set_and_save(get_ground_pressure());
+    _base_pressure.notify();
 }
 
 // return altitude difference in meters between current pressure and a


### PR DESCRIPTION
This allows zeroing depth from gcs via command_long
