### PR TITLE
Sub: Ditch control mode RC switch logic

### DIFF
--- a/ArduSub/ArduSub.cpp
+++ b/ArduSub/ArduSub.cpp
@@ -284,10 +284,9 @@ void Sub::fast_loop()
 // called at 100hz
 void Sub::rc_loop()
 {
-    // Read radio and 3-position switch on radio
+    // Read radio
     // -----------------------------------------
     read_radio();
-    read_control_switch();
 }
 
 // throttle_loop - should be run at 50 hz

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -948,7 +948,6 @@ private:
     void print_divider(void);
     void print_enabled(bool b);
     void report_version();
-    void read_control_switch();
     bool check_if_auxsw_mode_used(uint8_t auxsw_mode_check);
     bool check_duplicate_auxsw(void);
     void reset_control_switch();

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -262,13 +262,6 @@ private:
     control_mode_t prev_control_mode;
     mode_reason_t prev_control_mode_reason = MODE_REASON_UNKNOWN;
 
-    // Structure used to detect changes in the flight mode control switch
-    struct {
-        int8_t debounced_switch_position;   // currently used switch position
-        int8_t last_switch_position;        // switch position in previous iteration
-        uint32_t last_edge_time_ms;         // system time that switch position was last changed
-    } control_switch_state;
-
     struct {
         bool running;
         float max_speed;
@@ -950,7 +943,6 @@ private:
     void report_version();
     bool check_if_auxsw_mode_used(uint8_t auxsw_mode_check);
     bool check_duplicate_auxsw(void);
-    void reset_control_switch();
     uint8_t read_3pos_switch(int16_t radio_in);
     void read_aux_switches();
     void init_aux_switches();

--- a/ArduSub/switches.cpp
+++ b/ArduSub/switches.cpp
@@ -49,11 +49,6 @@ bool Sub::check_duplicate_auxsw(void)
     return ret;
 }
 
-void Sub::reset_control_switch()
-{
-    control_switch_state.last_switch_position = control_switch_state.debounced_switch_position = -1;
-}
-
 // read_3pos_switch
 uint8_t Sub::read_3pos_switch(int16_t radio_in)
 {
@@ -222,7 +217,7 @@ void Sub::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
             }else{
                 // return to flight mode switch's flight mode if we are currently in RTL
                 if (control_mode == RTL) {
-                    reset_control_switch();
+//                    reset_control_switch();
                 }
             }
             break;
@@ -371,7 +366,7 @@ void Sub::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
             }else{
                 // return to flight mode switch's flight mode if we are currently in AUTO
                 if (control_mode == AUTO) {
-                    reset_control_switch();
+//                    reset_control_switch();
                 }
             }
             break;
@@ -384,7 +379,7 @@ void Sub::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
                 case AUX_SWITCH_MIDDLE:
                     // restore flight mode based on flight mode switch position
                     if (control_mode == AUTOTUNE) {
-                        reset_control_switch();
+//                        reset_control_switch();
                     }
                     break;
                 case AUX_SWITCH_HIGH:
@@ -525,7 +520,7 @@ void Sub::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
             }else{
                 // return to flight mode switch's flight mode if we are currently in BRAKE
                 if (control_mode == BRAKE) {
-                    reset_control_switch();
+//                    reset_control_switch();
                 }
             }
             break;
@@ -537,7 +532,7 @@ void Sub::do_aux_switch_function(int8_t ch_function, uint8_t ch_flag)
             } else {
                 // return to flight mode switch's flight mode if we are currently in throw mode
                 if (control_mode == THROW) {
-                    reset_control_switch();
+//                    reset_control_switch();
                 }
             }
             break;

--- a/ArduSub/system.cpp
+++ b/ArduSub/system.cpp
@@ -300,7 +300,7 @@ void Sub::init_ardupilot()
 
     // initialise the flight mode and aux switch
     // ---------------------------
-    reset_control_switch();
+//    reset_control_switch();
     init_aux_switches();
 
     startup_INS_ground();


### PR DESCRIPTION
Call set_mode() directly from joystick button handler, the RC 'mode switch' logic is removed.