### PR TITLE
Fix motor factors for Vectored 6DOF frame

### DIFF
--- a/libraries/AP_Motors/AP_Motors6DOF.cpp
+++ b/libraries/AP_Motors/AP_Motors6DOF.cpp
@@ -129,14 +129,14 @@ void AP_Motors6DOF::setup_motors(motor_frame_class frame_class, motor_frame_type
 	    	break;
 
 	    case SUB_FRAME_VECTORED_6DOF:
-	    	add_motor_raw_6dof(AP_MOTORS_MOT_1,		0,				0,				1.0f,			0,					1.0f,				-1.0f,			1);
-	    	add_motor_raw_6dof(AP_MOTORS_MOT_2,		0,				0,				-1.0f,			0,					1.0f,				1.0f,			2);
-	    	add_motor_raw_6dof(AP_MOTORS_MOT_3,		0,				0,				-1.0f,			0,					-1.0f,				-1.0f, 			3);
-	    	add_motor_raw_6dof(AP_MOTORS_MOT_4,		0,				0,				1.0f,			0,					-1.0f,				1.0f,			4);
-	    	add_motor_raw_6dof(AP_MOTORS_MOT_5,		-1.0f,			1.0f,			0,				-1.0f,				0,					0,				5);
-	    	add_motor_raw_6dof(AP_MOTORS_MOT_6,		1.0f,			1.0f,			0,				-1.0f,				0,					0,				6);
-	    	add_motor_raw_6dof(AP_MOTORS_MOT_7,		-1.0f,			-1.0f,			0,				-1.0f,				0,					0,				7);
-	    	add_motor_raw_6dof(AP_MOTORS_MOT_8,		1.0f,			-1.0f,			0,				-1.0f,				0,					0,				8);
+	    	add_motor_raw_6dof(AP_MOTORS_MOT_1,		0,				0,				1.0f,			0,					-1.0f,				1.0f,			1);
+	    	add_motor_raw_6dof(AP_MOTORS_MOT_2,		0,				0,				-1.0f,			0,					-1.0f,				-1.0f,			2);
+	    	add_motor_raw_6dof(AP_MOTORS_MOT_3,		0,				0,				-1.0f,			0,					1.0f,				1.0f, 			3);
+	    	add_motor_raw_6dof(AP_MOTORS_MOT_4,		0,				0,				1.0f,			0,					1.0f,				-1.0f,			4);
+	    	add_motor_raw_6dof(AP_MOTORS_MOT_5,		1.0f,			-1.0f,			0,				-1.0f,				0,					0,				5);
+	    	add_motor_raw_6dof(AP_MOTORS_MOT_6,		-1.0f,			-1.0f,			0,				-1.0f,				0,					0,				6);
+	    	add_motor_raw_6dof(AP_MOTORS_MOT_7,		1.0f,			1.0f,			0,				-1.0f,				0,					0,				7);
+	    	add_motor_raw_6dof(AP_MOTORS_MOT_8,		-1.0f,			1.0f,			0,				-1.0f,				0,					0,				8);
 	    	break;
 
 	    case SUB_FRAME_VECTORED:


### PR DESCRIPTION
This PR fixes the motor factors for the Vectored6DOF frame type. The original values did not match the Vectored frame type and the roll and pitch values were reversed. 

This has been tested on a 6DOF frame and works great.