### PR TITLE
AP_NavEKF2: Do not assume zero sideslip with underwater vehicles

### DIFF
--- a/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
+++ b/libraries/AP_NavEKF2/AP_NavEKF2_Control.cpp
@@ -396,10 +396,9 @@ bool NavEKF2_core::use_compass(void) const
  */
 bool NavEKF2_core::assume_zero_sideslip(void) const
 {
-    // we don't assume zero sideslip for ground vehicles as EKF could
-    // be quite sensitive to a rapid spin of the ground vehicle if
-    // traction is lost
-    return _ahrs->get_fly_forward() && _ahrs->get_vehicle_class() != AHRS_VEHICLE_GROUND;
+    // we don't assume zero sideslip for ground and underwater vehicles
+    // as EKF could be quite sensitive to a rapid spin over the ground plane
+    return _ahrs->get_fly_forward() && _ahrs->get_vehicle_class() != AHRS_VEHICLE_GROUND && _ahrs->get_vehicle_class() != AHRS_VEHICLE_SUBMARINE;
 }
 
 // set the LLH location of the filters NED origin


### PR DESCRIPTION
Fix #130 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>